### PR TITLE
fix compiling errors for esp32

### DIFF
--- a/include/rl_tools/nn/layers/dense/operations_esp32/dsp.h
+++ b/include/rl_tools/nn/layers/dense/operations_esp32/dsp.h
@@ -5,7 +5,7 @@
 
 #include "../../../../devices/esp32.h"
 #include "../../../../nn/layers/dense/layer.h"
-#include "../../../../nn/mode.h"
+#include "../../../../mode/mode.h"
 
 #include "esp_dsp.h"
 

--- a/include/rl_tools/nn/layers/dense/operations_esp32/opt.h
+++ b/include/rl_tools/nn/layers/dense/operations_esp32/opt.h
@@ -5,7 +5,7 @@
 
 #include "../../../../devices/esp32.h"
 #include "../../../../nn/layers/dense/layer.h"
-#include "../../../../nn/mode.h"
+#include "../../../../mode/mode.h"
 
 RL_TOOLS_NAMESPACE_WRAPPER_START
 namespace rl_tools{

--- a/include/rl_tools/nn/layers/dense/operations_generic.h
+++ b/include/rl_tools/nn/layers/dense/operations_generic.h
@@ -5,6 +5,7 @@
 
 #include "../../../containers/matrix/matrix.h"
 #include "../../../nn/parameters/operations_generic.h"
+#include "../../../nn/optimizers/adam/instance/operations_generic.h"
 
 #include "layer.h"
 #ifndef RL_TOOLS_FUNCTION_PLACEMENT

--- a/include/rl_tools/operations/esp32.h
+++ b/include/rl_tools/operations/esp32.h
@@ -3,7 +3,7 @@
 #pragma once
 #define RL_TOOLS_OPERATIONS_ESP32_H
 
-
+#include "../rl_tools.h"
 #ifndef RL_TOOLS_DEVICES_DISABLE_REDEFINITION_DETECTION
 RL_TOOLS_NAMESPACE_WRAPPER_START
 namespace rl_tools{

--- a/include/rl_tools/random/operations_esp32.h
+++ b/include/rl_tools/random/operations_esp32.h
@@ -11,7 +11,7 @@ RL_TOOLS_NAMESPACE_WRAPPER_START
 namespace rl_tools::random{
     template <typename DEV_SPEC>
     devices::random::ESP32::index_t default_engine(const devices::ESP32<DEV_SPEC>& dev, devices::random::ESP32::index_t seed = 1){
-        return default_engine(devices::Generic<DEV_SPEC>{}, seed);
+        return default_engine(devices::random::Generic<DEV_SPEC>{}, seed);
     };
     constexpr devices::random::ESP32::index_t next_max(const devices::random::ESP32& dev){
         return devices::random::ESP32::MAX_INDEX;


### PR DESCRIPTION
Below are the changes used to fix errors in commit fb5f1334:
Reference model.h from the new path.
Correct the incorrect reference to the Generic class in the default_engine function.